### PR TITLE
package.json: type module

### DIFF
--- a/packages/prong-editor/package.json
+++ b/packages/prong-editor/package.json
@@ -70,6 +70,7 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
Per https://nodejs.org/api/packages.html#type, this allows Node programs to import Prong correctly. (Which is admittedly a weird thing to do, but sometimes Engraft wants to do this.)